### PR TITLE
Fix min_laser_range from SLAM

### DIFF
--- a/config/slam.yaml
+++ b/config/slam.yaml
@@ -28,6 +28,7 @@ slam:
     transform_publish_period: 0.02 # If 0 never publishes odometry
     map_update_interval: 2.0
     resolution: 0.04
+    min_laser_range: 0.2
     max_laser_range: 12.0
     minimum_time_interval: 0.1
     transform_timeout: 0.2


### PR DESCRIPTION
This PR fixes an issue with the min_laser_range setting in the SLAM configuration for Rosbot 2 Pro. Previously, the parameter was set to 0.0m, which is below the minimum range of the Lidar sensor (0.2m). This caused the following warning during SLAM initialization:
```css
[WARN] [1739963139.979803220] [slam]: minimum laser range setting (0.0 m) exceeds the capabilities of the used Lidar (0.2 m)
```
Testing:
Tested on Rosbot 2 Pro.
Verified that SLAM initializes without warnings.
Confirmed normal mapping functionality.

Notes:
Please review and let me know if any further modifications are needed!
Thanks for maintaining this repo and supporting the community